### PR TITLE
enable scalar entry to ageCols

### DIFF
--- a/surveyIndex/R/getSurveyIdxStratMean.R
+++ b/surveyIndex/R/getSurveyIdxStratMean.R
@@ -3,7 +3,7 @@
 ##'
 ##' @title Survey index using the stratified mean method using ICES statistical rectangles as strata.
 ##' @param x DATRASraw object. Must contain a matrix: x[[2]]$Nage.
-##' ##' @param ageCols which columns of the Nage matrix should be included?
+##' @param ageCols which columns of the Nage matrix should be included?
 ##' @param doLog log-transform?
 ##' @return a matrix with survey indices
 ##' @export
@@ -18,7 +18,9 @@ function(x,ageCols,doLog=FALSE){
         byRec=aggregate(log(ysplit[[y]][[2]]$Nage[,ageCols]+1),by=list(ysplit[[y]][[2]]$StatRec),FUN="mean")
       }
     
-    res[y,]=colMeans(byRec[,-1])
+    if(length(ageCols) == 1){
+      res[y,] = mean(byRec[,-1])
+    }else res[y,]=colMeans(byRec[,-1])
     }
   res
 }


### PR DESCRIPTION
changes allow estimating the index for a pooled Nage vector by age, which is useful for non-age-structured models.