### PR TITLE
Improve exportSI, set.seed for redoSurveyIndex

### DIFF
--- a/surveyIndex/DESCRIPTION
+++ b/surveyIndex/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: surveyIndex
 Type: Package
 Title: Calculate survey indices of abundance from DATRAS exchange data.
-Version: 1.09
-Date: 2020-28-09
+Version: 1.10
+Date: 2023-04-06
 Author: Casper W. Berg
 Maintainer: Casper W. Berg <cbe@aqua.dtu.dk>
 Description: This is an implementation of the methods described in

--- a/surveyIndex/R/exportSI.R
+++ b/surveyIndex/R/exportSI.R
@@ -6,14 +6,18 @@
 ##' @param years vector of years
 ##' @param toy fraction of year the survey is conducted (between 0 and 1)
 ##' @param file filename to write to
-##' @param nam file description header 
+##' @param nam file description header
 ##' @return nothing
 ##' @export
 exportSI <-
-function(x,ages,years,toy,file,nam=""){
+function(x,ages,years,toy,file,nam="") {
   cat(nam,"\n",file=file)
   cat(range(as.numeric(as.character(years))),"\n",file=file,append=TRUE)
   cat("1 1 ",rep(toy,2),"\n",file=file,append=TRUE)
   cat(min(ages),max(ages),"\n",file=file,append=TRUE)
-  write.table(round(cbind(1,x[,]),4),file=file,row.names=FALSE,col.names=FALSE,append=TRUE)
+  colstokeep <- colnames(x) %in% ages
+  rowstokeep <- rownames(x) %in% years
+  if (all(isFALSE(colstokeep))) stop("None of the selected ages are in `x`")
+  if (all(isFALSE(rowstokeep))) stop("None of the selected years are in `x`")
+  write.table(round(cbind(1,x[rowstokeep,colstokeep]),4),file=file,row.names=FALSE,col.names=FALSE,append=TRUE)
 }

--- a/surveyIndex/R/getSurveyIdx.R
+++ b/surveyIndex/R/getSurveyIdx.R
@@ -7,9 +7,9 @@
 ##' @param x DATRASraw object
 ##' @param ages vector of ages
 ##' @param myids haul.ids for grid
-##' @param kvecP vector with spatial smoother max. basis dimension for each age group, strictly positive part of model 
-##' @param kvecZ vector with spatial smoother max. basis dimension for each age group, presence/absence part of model (ignored for Tweedie models) 
-##' @param gamma model degress of freedom inflation factor (see 'gamma' argument to gam() ) 
+##' @param kvecP vector with spatial smoother max. basis dimension for each age group, strictly positive part of model
+##' @param kvecZ vector with spatial smoother max. basis dimension for each age group, presence/absence part of model (ignored for Tweedie models)
+##' @param gamma model degress of freedom inflation factor (see 'gamma' argument to gam() )
 ##' @param cutOff treat observations below this value as zero
 ##' @param fam distribution, either "Gamma","LogNormal", or "Tweedie".
 ##' @param useBIC use BIC for smoothness selection (overrides 'gamma' argument)
@@ -18,9 +18,9 @@
 ##' @param method smoothness selection method used by 'gam'
 ##' @param predD optional DATRASraw object or data.frame (or named list with such objects, one for each year with names(predD) being the years) , defaults to NULL. If not null this is used as grid.
 ##' @param modelZ vector of model formulae for presence/absence part, one pr. age group (ignored for Tweedie models)
-##' @param length) 
+##' @param length)
 ##' @param modelP vector of model formulae for strictly positive repsonses, one pr. age group
-##' @param length) 
+##' @param length)
 ##' @param knotsP optional list of knots to gam, strictly positive repsonses
 ##' @param knotsZ optional list of knots to gam, presence/absence
 ##' @param predfix optional named list of extra variables (besides Gear, HaulDur, Ship, and TimeShotHour),  that should be fixed during prediction step (standardized)
@@ -47,7 +47,7 @@
 ##'         d<-fixAgeGroup(d,age=a,fun=ifelse(a==min(ages),"min","mean"))
 ##' }
 ##' d<-subset(d,Age>=min(ages))
-##' 
+##'
 ##' ###############################
 ##' ## Convert to numbers-at-age
 ##' ###############################
@@ -57,7 +57,7 @@
 ##' Nage<-mclapply(ALK,predict,mc.cores=mc.cores)
 ##' for(i in 1:length(ALK)) d.ysplit[[i]]$Nage=Nage[[i]];
 ##' dd <- do.call("c",d.ysplit)
-##' 
+##'
 ##' ##############
 ##' ## Fit model
 ##' ##############
@@ -68,22 +68,22 @@
 ##' kvZ <- kvP / 2;
 ##' mP <- rep("Year+s(lon,lat,k=kvecP[a],bs='ts')+s(Depth,bs='ts',k=6)+offset(log(HaulDur))",length(ages)  );
 ##' mZ <- rep("Year+s(lon,lat,k=kvecZ[a],bs='ts')+s(Depth,bs='ts',k=6)+offset(log(HaulDur))",length(ages)  );
-##' 
+##'
 ##' SIQ1 <- getSurveyIdx(dd,ages=ages,myids=grid[[3]],cutOff=0.1,kvecP=kvP,kvecZ=kvZ,
-##'          modelZ=mZ,modelP=mP,mc.cores=mc.cores) ## if errors are encountered, debug with mc.cores=1 
-##' 
+##'          modelZ=mZ,modelP=mP,mc.cores=mc.cores) ## if errors are encountered, debug with mc.cores=1
+##'
 ##' strat.mean<-getSurveyIdxStratMean(dd,ages)
-##' 
+##'
 ##' ## plot indices, distribution map, and estimated depth effects
 ##' surveyIdxPlots(SIQ1,dd,cols=ages,alt.idx=strat.mean,grid[[3]],par=list(mfrow=c(3,3)),legend=FALSE,
 ##'                select="index",plotByAge=FALSE)
-##' 
+##'
 ##' surveyIdxPlots(SIQ1,dd,cols=ages,alt.idx=NULL,grid[[3]],par=list(mfrow=c(3,3)),legend=FALSE,
 ##'                 colors=rev(heat.colors(8)),select="map",plotByAge=FALSE)
-##' 
+##'
 ##' surveyIdxPlots(SIQ1,dd,cols=ages,alt.idx=NULL,grid[[3]],par=list(mfrow=c(3,3)),
 ##'                 legend=FALSE,select="2",plotByAge=FALSE)
-##' 
+##'
 ##' ## Calculate internal concistency and export to file
 ##' internalCons(SIQ1$idx)
 ##' exportSI(SIQ1$idx,ages=ages,years=levels(dd$Year),toy=mean(dd$timeOfYear),file="out.dat",
@@ -95,12 +95,12 @@ getSurveyIdx <-
     function(x,ages,myids,kvecP=rep(12*12,length(ages)),kvecZ=rep(8*8,length(ages)),gamma=1.4,cutOff=1,fam="Gamma",useBIC=FALSE,nBoot=1000,mc.cores=1,method="ML",predD=NULL,
              modelZ=rep("Year+s(lon,lat,k=kvecZ[a],bs='ts')+s(Ship,bs='re',by=dum)+s(Depth,bs='ts')+s(TimeShotHour,bs='cc')",length(ages)  ),modelP=rep("Year+s(lon,lat,k=kvecP[a],bs='ts')+s(Ship,bs='re',by=dum)+s(Depth,bs='ts')+s(TimeShotHour,bs='cc')",length(ages)  ),knotsP=NULL,knotsZ=NULL,predfix=NULL,linkZ="logit", CIlevel=0.95,...
              ){
-        
+
         if(is.null(x$Nage)) stop("No age matrix 'Nage' found.");
         if(is.null(colnames(x$Nage))) stop("No colnames found on 'Nage' matrix.");
         if(length(modelP)<length(ages)) stop(" length(modelP) < length(ages)");
         if(length(kvecP)<length(ages)) stop(" length(kvecP) < length(ages)");
-        if(fam[1]!="Tweedie"){ 
+        if(fam[1]!="Tweedie"){
             if(length(modelZ)<length(ages)) stop(" length(modelZ) < length(ages)");
             if(length(kvecZ)<length(ages)) stop(" length(kvecZ) < length(ages)");
         }
@@ -116,18 +116,18 @@ getSurveyIdx <-
         zModels=list()
         gPreds=list() ##last data year's predictions
         gPreds2=list() ## all years predictions
-        gPreds2.CV=list() ## coefficient of variation of previous 
+        gPreds2.CV=list() ## coefficient of variation of previous
         allobs=list() ## response vector (zeroes and positive)
         resid=list() ## residuals
         predDc = predD ##copy of predD
-        
+
         if (exists(".Random.seed")) {
             oldseed <- get(".Random.seed", .GlobalEnv)
             oldRNGkind <- RNGkind()
             on.exit( { do.call("RNGkind", as.list(oldRNGkind)); assign(".Random.seed", oldseed, .GlobalEnv) }  )
         }
         set.seed(314159265)
-            
+
         yearNum=as.numeric(as.character(x$Year));
         yearRange=min(yearNum):max(yearNum);
 
@@ -135,7 +135,7 @@ getSurveyIdx <-
         gearNames=names(xtabs(~Gear,data=x[[2]]))
         myGear=names(xtabs(~Gear,data=x[[2]]))[which.max(xtabs(~Gear,data=x[[2]]))]
         if(!is.null(predfix$Gear)) myGear = predfix$Gear
-        
+
         resMat=matrix(NA,nrow=length(yearRange),ncol=length(ages));
         upMat=resMat;
         loMat=resMat;
@@ -145,7 +145,7 @@ getSurveyIdx <-
             ddd$A1=ddd$Nage[,age]
             gammaPos=gamma;
             gammaZ=gamma;
-            
+
             if(useBIC){
                 nZ=nrow(ddd);
                 nPos=nrow(subset(ddd,A1>cutOff));
@@ -157,32 +157,32 @@ getSurveyIdx <-
             if(famVec[a]=="LogNormal"){
                 f.pos = as.formula( paste( "log(A1) ~",modelP[a]));
                 f.0 = as.formula( paste( "A1>",cutOff," ~",modelZ[a]));
-                
+
                 print(system.time(m.pos<-DATRAS:::tryCatch.W.E(gam(f.pos,data=subset(ddd,A1>cutOff),gamma=gammaPos,method=method,knots=knotsP,na.action=na.fail,...))$value));
 
                 if(class(m.pos)[2] == "error") {
                     print(m.pos)
                     stop("Error occured for age ", a, " in the positive part of the model\n", "Try reducing the number of age groups or decrease the basis dimension of the smooths, k\n")
                 }
-                
+
                 print(system.time(m0<-DATRAS:::tryCatch.W.E(gam(f.0,gamma=gammaZ,data=ddd,family=binomial(link=linkZ),method=method,knots=knotsZ,na.action=na.fail,...))$value));
 
                 if(class(m0)[2] == "error") {
                     print(m0)
                     stop("Error occured for age ", a, " in the binomial part of the model\n", "Try reducing the number of age groups or decrease the basis dimension of the smooths, k\n")
                 }
-                
+
             } else if(famVec[a]=="Gamma"){
                 f.pos = as.formula( paste( "A1 ~",modelP[a]));
                 f.0 = as.formula( paste( "A1>",cutOff," ~",modelZ[a]));
-                
+
                 print(system.time(m.pos<-DATRAS:::tryCatch.W.E(gam(f.pos,data=subset(ddd,A1>cutOff),family=Gamma(link="log"),gamma=gammaPos,method=method,knots=knotsP,na.action=na.fail,...))$value));
 
                 if(class(m.pos)[2] == "error") {
                     print(m.pos)
                     stop("Error occured for age ", a, " in the positive part of the model\n", "Try reducing the number of age groups or decrease the basis dimension of the smooths, k\n")
                 }
-                
+
                 print(system.time(m0<-DATRAS:::tryCatch.W.E(gam(f.0,gamma=gammaZ,data=ddd,family=binomial(link=linkZ),method=method,knots=knotsZ,na.action=na.fail,...))$value));
 
                 if(class(m0)[2] == "error") {
@@ -214,22 +214,22 @@ getSurveyIdx <-
                 totll = logLik(m.pos)[1]
             } else {
                 p0p =(1-predict(m0,type="response"))
-                ppos=p0p[ddd$A1>cutOff] 
+                ppos=p0p[ddd$A1>cutOff]
                 p0m1=p0p[ddd$A1<=cutOff]
                 if(famVec[a]=="Gamma")  totll=sum(log(p0m1))+sum(log(1-ppos))+logLik(m.pos)[1];
                 ## if logNormal model, we must transform til log-likelihood to be able to use AIC
                 ## L(y) = prod( dnorm( log y_i, mu_i, sigma^2) * ( 1 / y_i ) ) => logLik(y) = sum( log[dnorm(log y_i, mu_i, sigma^2)]  - log( y_i ) )
                 if(famVec[a]=="LogNormal") totll=sum(log(p0m1))+ sum(log(1-ppos)) + logLik(m.pos)[1] - sum(m.pos$y);
             }
-            
+
             if(is.null(predD)) predD=subset(ddd,haul.id %in% myids);
             res=numeric(length(yearRange));
             lores=res;
             upres=res;
             gp2=list()
             gp2.cv=list()
-            
-            for(y in levels(ddd$Year)){ 
+
+            for(y in levels(ddd$Year)){
                 ## take care of years with all zeroes
                 if(!any(ddd$A1[ddd$Year==y]>cutOff)){
                     res[which(as.character(yearRange)==y)]=0;
@@ -260,7 +260,7 @@ getSurveyIdx <-
                     terms.pos=terms(m.pos)
                     if(!is.null(m.pos$offset)){
                         off.num.pos <- attr(terms.pos, "offset")
-                        for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos, 
+                        for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos,
                                                                             "variables")[[i + 1]], predD)
                     }
                     p.1 =Xp.1%*%coef(m.pos)+OS.pos;
@@ -271,7 +271,7 @@ getSurveyIdx <-
                         terms.0=terms(m0)
                         if(!is.null(m0$offset)){
                             off.num.0 <- attr(terms.0, "offset")
-                            for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0, 
+                            for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0,
                                                                         "variables")[[i + 1]], predD)
                         }
                         p.0 = m0$family$linkinv(Xp.0%*%brp.0+OS0);
@@ -285,7 +285,7 @@ getSurveyIdx <-
                     next;
                 }
                 sig2=m.pos$sig2;
-                
+
                 if(famVec[a]=="Gamma") { res[which(as.character(yearRange)==y)] = sum(p.0*exp(p.1)); gPred=p.0*exp(p.1) }
                 if(famVec[a]=="LogNormal")  { res[which(as.character(yearRange)==y)] = sum(p.0*exp(p.1+sig2/2)); gPred=p.0*exp(p.1+sig2/2) }
                 if(famVec[a] %in% c("Tweedie","negbin"))  { res[which(as.character(yearRange)==y)] = sum(exp(p.1)); gPred=exp(p.1) }
@@ -298,7 +298,7 @@ getSurveyIdx <-
                         terms.0=terms(m0)
                         if(!is.null(m0$offset)){
                             off.num.0 <- attr(terms.0, "offset")
-                            for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0, 
+                            for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0,
                                                                         "variables")[[i + 1]], predD)
                         }
                         rep0=m0$family$linkinv(Xp.0%*%t(brp.0)+OS0);
@@ -307,14 +307,14 @@ getSurveyIdx <-
                     terms.pos=terms(m.pos)
                     if(!is.null(m.pos$offset)){
                         off.num.pos <- attr(terms.pos, "offset")
-                        for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos, 
+                        for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos,
                                                                             "variables")[[i + 1]], predD)
                     }
                     if(famVec[a]=="LogNormal"){
                         rep1=exp(Xp.1%*%t(brp.1)+sig2/2+OS.pos);
                     } else {
                         rep1=exp(Xp.1%*%t(brp.1)+OS.pos);
-                    } 
+                    }
 
                     if(!famVec[a] %in% c("Tweedie","negbin")){
                         idxSamp = colSums(rep0*rep1);
@@ -368,7 +368,7 @@ getSurveyIdx <-
 
 
 ##' Re-compute standardized survey indices for an alternative grid from a previous fitted "surveyIdx" model.
-##' 
+##'
 ##' @title Re-compute standardized survey indices for an alternative grid from a previous fitted "surveyIdx" model.
 ##' @param x DATRASraw dataset
 ##' @param model object of class "surveyIdx" as created by "getSurveyIdx"
@@ -380,12 +380,12 @@ getSurveyIdx <-
 ##' @return An object of class "surveyIdx"
 ##' @importFrom MASS mvrnorm
 ##' @export
-redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.cores=1){        
+redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.cores=1){
     ages = as.numeric(colnames(model$idx))
     dataAges <- model$dataAges
     famVec = model$family
     cutOff = model$cutOff
-    
+
     yearNum=model$yearNum
     yearRange=min(yearNum):max(yearNum);
 
@@ -393,12 +393,20 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
     gPreds2=list() ## all years predictions
     gPreds2.CV=list()
     predDc = predD
-    
-    myGear=model$refGear 
-    
+
+    myGear=model$refGear
+
     resMat=matrix(NA,nrow=length(yearRange),ncol=length(ages));
     upMat=resMat;
     loMat=resMat;
+
+    if (exists(".Random.seed")) {
+      oldseed <- get(".Random.seed", .GlobalEnv)
+      oldRNGkind <- RNGkind()
+      on.exit( { do.call("RNGkind", as.list(oldRNGkind)); assign(".Random.seed", oldseed, .GlobalEnv) }  )
+    }
+    set.seed(314159265)
+
     do.one.a<-function(a){
         age = which(dataAges==ages[a])
         ddd=x[[2]]; ddd$dum=1.0;
@@ -413,9 +421,9 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
         gp2=list()
         gp2.cv=list()
         do.one.y<-function(y){
-            
+
             cat("Doing year ",y,"\n")
-            
+
             if(is.list(predDc) && !class(predDc)%in%c("data.frame","DATRASraw")) predD = predDc[[as.character(y)]]
             if(is.null(predD)) stop(paste("Year",y," not found in predD"))
 
@@ -445,7 +453,7 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
                 terms.pos=terms(m.pos)
                 if(!is.null(m.pos$offset)){
                     off.num.pos <- attr(terms.pos, "offset")
-                    for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos, 
+                    for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos,
                                                                             "variables")[[i + 1]], predD)
                 }
                 p.1 =Xp.1%*%coef(m.pos)+OS.pos;
@@ -456,7 +464,7 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
                     terms.0=terms(m0)
                     if(!is.null(m0$offset)){
                         off.num.0 <- attr(terms.0, "offset")
-                        for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0, 
+                        for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0,
                                                                     "variables")[[i + 1]], predD)
                     }
                     p.0 = m0$family$linkinv(Xp.0%*%brp.0+OS0);
@@ -471,7 +479,7 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
             if(famVec[a]=="Gamma") { idx <- sum(p.0*exp(p.1)); gPred=p.0*exp(p.1) }
             if(famVec[a]=="LogNormal")  { idx <- sum(p.0*exp(p.1+sig2/2)); gPred=p.0*exp(p.1+sig2/2) }
             if(famVec[a] %in% c("Tweedie","negbin"))  { idx <- sum(exp(p.1)); gPred=exp(p.1) }
-            
+
             if(nBoot>10){
                 brp.1=mvrnorm(n=nBoot,coef(m.pos),m.pos$Vp);
                 if(!famVec[a] %in% c("Tweedie","negbin")){
@@ -480,8 +488,8 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
                     terms.0=terms(m0)
                     if(!is.null(m0$offset)){
                         off.num.0 <- attr(terms.0, "offset")
-                        
-                        for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0, 
+
+                        for (i in off.num.0) OS0 <- OS0 + eval(attr(terms.0,
                                                                     "variables")[[i + 1]], predD)
                     }
                     rep0=m0$family$linkinv(Xp.0%*%t(brp.0)+OS0);
@@ -490,17 +498,17 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
                 terms.pos=terms(m.pos)
                 if(!is.null(m.pos$offset)){
                     off.num.pos <- attr(terms.pos, "offset")
-                    
-                    for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos, 
+
+                    for (i in off.num.pos) OS.pos <- OS.pos + eval(attr(terms.pos,
                                                                         "variables")[[i + 1]], predD)
                 }
-                
-                
+
+
                 if(famVec[a]=="LogNormal"){
                     rep1=exp(Xp.1%*%t(brp.1)+sig2/2+OS.pos);
                 } else {
                     rep1=exp(Xp.1%*%t(brp.1)+OS.pos);
-                } 
+                }
 
                 if(!famVec[a] %in% c("Tweedie","negbin")){
                     idxSamp = colSums(rep0*rep1);
@@ -519,7 +527,7 @@ redoSurveyIndex<-function(x,model,predD=NULL,myids,nBoot=1000,predfix=list(),mc.
         } ## rof years
         yres = parallel::mclapply(levels(ddd$Year),do.one.y,mc.cores=mc.cores)
         for(y in levels(ddd$Year)) {
-            ii = which(as.character(yearRange)==y) 
+            ii = which(as.character(yearRange)==y)
             res[ii] = yres[[ii]]$res
             upres[ii] = yres[[ii]]$upres
             lores[ii] = yres[[ii]]$lores
@@ -558,5 +566,5 @@ print.surveyIdx <- function(x){
     cat("CutOff value",x$cutOff,"\n")
     cat("===========================\n")
     print(x$idx)
-    
+
 }


### PR DESCRIPTION
Three small changes:

* exportSI had arguments ages and years that were just added to the heading of the file and everything was extracted, now they are used to select some ages and years
* redoSurveyIndex: copied the set.seed code to get a reproducible index with that function
* Updated the version to 1.10 and used a correct date format which caused warnings before